### PR TITLE
Day 1 Part 2

### DIFF
--- a/Day1.ps1
+++ b/Day1.ps1
@@ -11,7 +11,7 @@ function Measure-LargerThanPrevious {
         $slidingWindowSize = 3
         $previousWindowSum = -1
         $firstWindow = $true
-        $canWindow = $true;
+        $canWindow = $true
 
         # Now enumerate though each one
         for ($i = 0; $i -lt $Inputs.Count; $i++) {

--- a/Day1.ps1
+++ b/Day1.ps1
@@ -21,7 +21,7 @@ function Measure-LargerThanPrevious {
                     $currentWindowSum += $Inputs[$i + $j]
                 }
                 else {
-                    $canWindow = $falses
+                    $canWindow = $false
                 }
             }
 

--- a/Day1.ps1
+++ b/Day1.ps1
@@ -8,22 +8,40 @@ function Measure-LargerThanPrevious {
     )
     process {
         $measurementsLargerThanPrevious = 0
-
-        # We special case the first value to do nothing
-        Write-Verbose -Message "$($Inputs[0]) (N/A - no previous measurement)"
+        $slidingWindowSize = 3
+        $previousWindowSum = -1
+        $firstWindow = $true
+        $canWindow = $true;
 
         # Now enumerate though each one
-        for ($i = 1; $i -lt $Inputs.Count; $i++) {
-            if ($Inputs[$i] -gt $Inputs[$i - 1]) {
-                Write-Verbose -Message "$($Inputs[$i]) (increased)"
-                $measurementsLargerThanPrevious++
+        for ($i = 0; $i -lt $Inputs.Count; $i++) {
+            $currentWindowSum = 0
+            for ($j = 0; $j -lt $slidingWindowSize; $j++) {
+                if ($i + $j -lt $Inputs.Count) {
+                    $currentWindowSum += $Inputs[$i + $j]
+                }
+                else {
+                    $canWindow = $falses
+                }
             }
-            elseif ($Inputs[$i] -eq $Inputs[$i - 1]) {
-                # The specification didn't say what to do in this scenario? Be silent?
-                Write-Verbose "$($Inputs[$i]) (no change)"
-            }
-            else {
-                Write-Verbose -Message "$($Inputs[$i]) (decreased)"
+
+            if ($canWindow) {
+                if ($firstWindow) {
+                    $firstWindow = $false
+                    Write-Verbose -Message "$([Char]($i + 65)): $currentWindowSum (N/A - no previous sum)"
+                }
+                elseif ($currentWindowSum -gt $previousWindowSum) {
+                    Write-Verbose -Message "$([Char]($i + 65)): $currentWindowSum (increased)"
+                    $measurementsLargerThanPrevious++
+                }
+                elseif ($currentWindowSum -eq $previousWindowSum) {
+                    Write-Verbose "$([Char]($i + 65)): $currentWindowSum (no change)"
+                }
+                else {
+                    Write-Verbose -Message "$([Char]($i + 65)): $currentWindowSum (decreased)"
+                }
+
+                $previousWindowSum = $currentWindowSum
             }
         }
 
@@ -43,5 +61,6 @@ $inputValues = @(
     260,
     263
 )
+#$inputValues = Get-Content -Path "$PSScriptRoot\input.txt"
 
 Measure-LargerThanPrevious -Inputs $inputValues -Verbose


### PR DESCRIPTION
https://adventofcode.com/2021/day/1#part2

I didn't realize there was a part 2 here.

So the changes from this wants to do a type of sliding Window, in this case because we're still being passed an array we'll play games with the index, being careful not to over index as we get towards the edges.

We'll allow the sliding window size to be configurable and we'll maintain the previous window size to avoid recalculating any more than we need to.

We pay a few costs by maintaining a boolean to indicate if this is our first window in the loop (with enough effort you might be able to avoid this by playing with the indexes more; but this works).

We also pay a cost to ensure we can window by using a boolean to indicate that it is possible. There are a bunch of subtle bugs/performance issues here:

1. We could optimize the loop by exiting as soon as we can no longer window; as it is written it will continue to enumerate until the last element of the array
2. We assume that `$canWindow` is true in all cases until it isn't.  This is not super stateful of the assumption, we could, if we wanted to be more stateful assign it to `$true` each time the explicit check passes in lines 20-22.

We play some weird games to get the `-Verbose` formatting similar to the example output, this breaks as soon as you go past `$i=26` but PowerShell is extremely forgiving here.