### PR TITLE
Day 2 Part 1

### DIFF
--- a/Day2.ps1
+++ b/Day2.ps1
@@ -1,0 +1,50 @@
+# Copyright (c) 2021 Ace Olszowka
+# https://adventofcode.com/2021/day/2
+# What do you get if you multiply your final horizontal position by your final depth?
+
+function Invoke-Dive {
+    [CmdletBinding()]
+    param (
+        [string[]]$Commands
+    )
+    process {
+        [System.Drawing.Point]$currentPosition = [System.Drawing.Point]::new(0, 0)
+
+        foreach ($command in $Commands) {
+            [string[]]$splitCommand = $command.Split(' ')
+            [int]$distance = [int]::Parse($splitCommand[1])
+
+            switch ($splitCommand[0]) {
+                'forward' {
+                    $currentPosition.X = $currentPosition.X + $distance
+                }
+                'down' {
+                    $currentPosition.Y = $currentPosition.Y + $distance
+                }
+                'up' {
+                    $currentPosition.Y = $currentPosition.Y - $distance
+                }
+                Default {
+                    Write-Error -Message "Unknown Command $($splitCommand[0])" 
+                }
+            }
+
+            Write-Verbose -Message "$command - Current Position $($currentPosition.ToString())"
+        }
+
+        $finalPosition = $currentPosition.X * $currentPosition.Y
+        $finalPosition
+    }
+}
+
+$commands = @(
+    'forward 5',
+    'down 5',
+    'forward 8',
+    'up 3',
+    'down 8',
+    'forward 2'
+)
+#$commands = Get-Content "$PSScriptRoot\input.txt"
+
+Invoke-Dive -Commands $commands -Verbose


### PR DESCRIPTION
https://adventofcode.com/2021/day/2

Again many of these are assuming that we are taking in the commands as a completely loaded `string[]` without leveraging the pipeline at all.

In here we leverage the .NET Type `System.Drawing.Point` to serve as our coordinate data structure.

We do a naive `string.Split` on the command and then assume that the data was given to us in a clean fashion where we can easily parse to an `int`. We then `switch` on the first half of the command, assuming that again the user input was valid and in that exact format then perform the desired operation to move our current position.