### PR TITLE
Day 3

### DIFF
--- a/Day3.ps1
+++ b/Day3.ps1
@@ -1,0 +1,73 @@
+# Copyright (c) 2021 Ace Olszowka
+# https://adventofcode.com/2021/day/3
+# What is the power consumption of the submarine?
+
+function Get-Report {
+    [CmdletBinding()]
+    param (
+        [string[]]$DiagnosticReports
+    )
+
+    [System.Collections.Generic.Dictionary[int, int]]$frequencyTable = [System.Collections.Generic.Dictionary[int, int]]::new()
+
+    $numberOfBits = $DiagnosticReports[0].Length
+    # Initialize the Table
+    for ($i = 0; $i -lt $numberOfBits; $i++) {
+        $frequencyTable.Add($i, 0)
+    }
+
+    # Load the frequency for the entire report
+    foreach ($report in $DiagnosticReports) {
+        $index = 0
+        foreach ($bit in $report.GetEnumerator()) {
+            if ($bit -eq '1') {
+                $frequencyTable[$index] = $frequencyTable[$index] + 1
+            }
+            $index++
+        }
+    }
+
+    # Calculate the Gamma and epislon Rate
+    $midPoint = [System.Math]::Floor($DiagnosticReports.Length / 2)
+    [System.Text.StringBuilder]$gammaRateString = [System.Text.StringBuilder]::new()
+    [System.Text.StringBuilder]$epislonRateString = [System.Text.StringBuilder]::new()
+
+
+    for ($i = 0; $i -lt $numberOfBits; $i++) {
+        if ($frequencyTable[$i] -gt $midPoint) {
+            $gammaRateString.Append('1') | Out-Null
+            $epislonRateString.Append('0') | Out-Null
+        }
+        else {
+            $gammaRateString.Append('0') | Out-Null
+            $epislonRateString.Append('1') | Out-Null
+        }
+    }
+
+    $gammaRate = [System.Convert]::ToInt32($gammaRateString.ToString(), 2)
+    $epislonRate = [System.Convert]::ToInt32($epislonRateString.ToString(), 2)
+
+    Write-Verbose "Gamma Rate $($gammaRateString.ToString()) ($gammaRate)"
+    Write-Verbose "Epislon Rate $($epislonRateString.ToString()) ($epislonRate)"
+
+    $powerConsumption = $gammaRate * $epislonRate
+    $powerConsumption
+}
+
+$diagReports = @(
+    '00100',
+    '11110',
+    '10110',
+    '10111',
+    '10101',
+    '01111',
+    '00111',
+    '11100',
+    '10000',
+    '11001',
+    '00010',
+    '01010'
+)
+#$diagReports = Get-Content "$PSScriptRoot\input.txt"
+
+Get-Report -DiagnosticReports $diagReports -Verbose

--- a/Day3.ps1
+++ b/Day3.ps1
@@ -27,30 +27,30 @@ function Get-Report {
         }
     }
 
-    # Calculate the Gamma and epislon Rate
+    # Calculate the Gamma and epsilon Rate
     $midPoint = [System.Math]::Floor($DiagnosticReports.Length / 2)
     [System.Text.StringBuilder]$gammaRateString = [System.Text.StringBuilder]::new()
-    [System.Text.StringBuilder]$epislonRateString = [System.Text.StringBuilder]::new()
+    [System.Text.StringBuilder]$epsilonRateString = [System.Text.StringBuilder]::new()
 
 
     for ($i = 0; $i -lt $numberOfBits; $i++) {
         if ($frequencyTable[$i] -gt $midPoint) {
             $gammaRateString.Append('1') | Out-Null
-            $epislonRateString.Append('0') | Out-Null
+            $epsilonRateString.Append('0') | Out-Null
         }
         else {
             $gammaRateString.Append('0') | Out-Null
-            $epislonRateString.Append('1') | Out-Null
+            $epsilonRateString.Append('1') | Out-Null
         }
     }
 
     $gammaRate = [System.Convert]::ToInt32($gammaRateString.ToString(), 2)
-    $epislonRate = [System.Convert]::ToInt32($epislonRateString.ToString(), 2)
+    $epsilonRate = [System.Convert]::ToInt32($epsilonRateString.ToString(), 2)
 
     Write-Verbose "Gamma Rate $($gammaRateString.ToString()) ($gammaRate)"
-    Write-Verbose "Epislon Rate $($epislonRateString.ToString()) ($epislonRate)"
+    Write-Verbose "Epsilon Rate $($epsilonRateString.ToString()) ($epsilonRate)"
 
-    $powerConsumption = $gammaRate * $epislonRate
+    $powerConsumption = $gammaRate * $epsilonRate
     $powerConsumption
 }
 


### PR DESCRIPTION
https://adventofcode.com/2021/day/3

This version utilizes a frequency table using a `Dictionary` combined with calculating the midpoint of the dataset to determine if `1` or `0` is more frequent. This has an issue if you have the same values equally, and this "fails open" `0` for gamma and `1` for epsilon.

The number of bits provided in the sample compared to the number of bits in the `actual` input seems to have changed, this is configured by assuming that all of the lines are identical in length and by reading the first line (assuming you get a first line). There is little to no error handling.

There could be some fun games played with something like `BitArray`, or I even suspect that there might be an elegant way using bit based operations to perform this, at very least to get the epsilon you could perform a binary not. I would be interested to see other solutions.

@nickkimbrough