### PR TITLE
Day 5 Part 1

### DIFF
--- a/Day5.ps1
+++ b/Day5.ps1
@@ -112,6 +112,9 @@ $points = Get-Lines -Path $PSScriptRoot\input.txt
 $lineResult = Get-LineOverlap -Points $points
 Out-VisualizeLines -PopulatedPoints $lineResult.PopulatedPoints -Max_X $lineResult.Max_X -Max_Y $lineResult.Max_Y
 
+# At how many points do at least two lines overlap?
+($lineResult.PopulatedPoints.GetEnumerator() | Select-Object -ExpandProperty Value | Where-Object { $_ -gt 1 } | Measure-Object).Count
+
 # # Testing
 # Write-Output "Starting x1"
 # Get-LinePoints -Start $([System.Drawing.Point]::new(1, 1)) -End $([System.Drawing.Point]::new(1, 3))

--- a/Day5.ps1
+++ b/Day5.ps1
@@ -1,0 +1,128 @@
+# Copyright (c) 2021 Ace Olszowka
+# https://adventofcode.com/2021/day/5
+# At how many points do at least two lines overlap?
+
+function Get-LinePoints {
+    [CmdletBinding()]
+    param (
+        [System.Drawing.Point]$Start,
+        [System.Drawing.Point]$End
+    )
+    process {
+        if ($End.X -eq $Start.X) {
+            $diff_y = [Math]::Abs($End.Y - $Start.Y)
+            $smallest_y = [Math]::Min($End.Y, $Start.Y)
+            for ($i = 0; $i -le $diff_y; $i++) {
+                [System.Drawing.Point]::new($End.X, $smallest_y + $i)
+            }
+        }
+        elseif ($End.Y -eq $Start.Y) {
+            $diff_x = [Math]::Abs($Start.X - $End.X)
+            $smallest_x = [Math]::Min($Start.X, $End.X)
+            for ($i = 0; $i -le $diff_x; $i++) {
+                [System.Drawing.Point]::new($smallest_x + $i, $End.Y)
+            }
+        }
+        else {
+            Write-Verbose -Message 'This method only supports straight lines'
+        }
+    }
+}
+
+function Get-Lines {
+    [CmdletBinding()]
+    param (
+        [string]$Path
+    )
+    process {
+        $rawInputs = Get-Content $Path
+        foreach ($rawInputLine in $rawInputs) {
+            $splitCoordinates = $rawInputLine.Split('->')
+
+            # Start
+            # Now Get the X and Y
+            $xyCordinates = $splitCoordinates[0].Split(',')
+            [System.Drawing.Point]$StartPoint = [System.Drawing.Point]::new([int]::Parse($xyCordinates[0]), [int]::Parse($xyCordinates[1]))
+
+            # End
+            # Now Get the X and Y
+            $xyCordinates = $splitCoordinates[1].Split(',')
+            [System.Drawing.Point]$EndPoint = [System.Drawing.Point]::new([int]::Parse($xyCordinates[0]), [int]::Parse($xyCordinates[1]))
+
+            # Generate the points for the line
+            Get-LinePoints -Start $StartPoint -End $EndPoint
+        }
+    }
+}
+
+function Get-LineOverlap {
+    [CmdletBinding()]
+    param (
+        [System.Drawing.Point[]]$Points
+    )
+    process {
+        [System.Collections.Generic.Dictionary[System.Drawing.Point, int]]$populatedPoints = [System.Collections.Generic.Dictionary[System.Drawing.Point, int]]::new()
+        $max_x = 0
+        $max_y = 0
+
+        foreach ($point in $Points) {
+            $max_x = [Math]::Max($max_x, $point.X)
+            $max_y = [Math]::Max($max_y, $point.Y)
+            if (-Not($populatedPoints.ContainsKey($point))) {
+                $populatedPoints.Add($point, 0)
+            }
+            $populatedPoints[$point]++
+        }
+
+        [PSCustomObject]@{
+            PopulatedPoints = $populatedPoints
+            Max_X = $max_x
+            Max_Y = $max_y
+        }
+        $populatedPoints
+    }
+}
+
+function Out-VisualizeLines {
+    [CmdletBinding()]
+    param (
+        [System.Collections.Generic.Dictionary[System.Drawing.Point, int]]$PopulatedPoints,
+        [int]$Max_X,
+        [int]$Max_Y
+    )
+    process {
+        [System.Text.StringBuilder]$visualization = [System.Text.StringBuilder]::new()
+        for ($y = 0; $y -le $max_y; $y++) {
+            for ($x = 0; $x -le $max_x; $x++) {
+                [System.Drawing.Point]$currentPoint = [System.Drawing.Point]::new($x, $y)
+                if ($PopulatedPoints.ContainsKey($currentPoint)) {
+                    $visualization.Append($PopulatedPoints[$currentPoint]) | Out-Null
+                }
+                else {
+                    $visualization.Append('.') | Out-Null
+                }
+            }
+            $visualization.AppendLine() | Out-Null
+        }
+        $visualization.ToString()
+    }
+}
+
+$points = Get-Lines -Path $PSScriptRoot\input.txt
+$lineResult = Get-LineOverlap -Points $points
+Out-VisualizeLines -PopulatedPoints $lineResult.PopulatedPoints -Max_X $lineResult.Max_X -Max_Y $lineResult.Max_Y
+
+# # Testing
+# Write-Output "Starting x1"
+# Get-LinePoints -Start $([System.Drawing.Point]::new(1, 1)) -End $([System.Drawing.Point]::new(1, 3))
+# Write-Output "Starting x1.1"
+# Get-LinePoints -End $([System.Drawing.Point]::new(1, 1)) -Start $([System.Drawing.Point]::new(1, 3))
+
+# Write-Output "Starting y1"
+# Get-LinePoints -Start $([System.Drawing.Point]::new(9, 7)) -End $([System.Drawing.Point]::new(7, 7))
+# Write-Output "Starting y1.1"
+# Get-LinePoints -End $([System.Drawing.Point]::new(9, 7)) -Start $([System.Drawing.Point]::new(7, 7))
+# Write-Output "Starting y2"
+# Get-LinePoints -Start $([System.Drawing.Point]::new(0, 9)) -End $([System.Drawing.Point]::new(2, 9))
+# Write-Output "Starting y2.1"
+# Get-LinePoints -End $([System.Drawing.Point]::new(0, 9)) -Start $([System.Drawing.Point]::new(2, 9))


### PR DESCRIPTION
https://adventofcode.com/2021/day/5

This implementation utilizes the `System.Drawing.Point` class to give a simple X,Y Data Structure that is well formed.

`Get-LinePoints` when given a starting and and end `Point` will generate all of the points in between. As per the specification this does not currently support diagonal lines but will throw up a verbose warning alerting you of this scenario. The specification seems to allow the points to come in an an arbitrary manner, which means this implementation needed to use the `Math.Abs` and `Math.Min/Math.Max` functions often to ensure that the logic worked. I suspect that there is a cleaner solution to this.

This output is then passed to `Get-LineOverlap` which will throw these points into a `Dictionary[Point,Int]` to indicate how many times a particular point is overlapped.

The `Out-VisualizeLines` is useful to give a visualization similar to the example to help in debugging.

Once the data is in the dictionary a simple selection where the count of overlap is greater than 1 is taken which will yield the answer for today.