### PR TITLE
Day 6 Part 2

### DIFF
--- a/Day6.ps1
+++ b/Day6.ps1
@@ -27,33 +27,33 @@ function Invoke-Simulation {
                 [PSCustomObject[]]$School
             )
             process {
-                [string]::Join(',', $($School | Select-Object -ExpandProperty RemainingDays))
+                [string]::Join(',', $($School))
             }
         }
     }
     process {
-        [System.Collections.Generic.List[PSCustomObject]]$school = [System.Collections.Generic.List[PSCustomObject]]::new()
+        [System.Collections.Generic.List[int]]$school = [System.Collections.Generic.List[int]]::new()
         # Initialize our School
         foreach ($fish in $StartingSchool) {
-            $school.Add($(New-LanternFish -RemainingDays $fish))
+            $school.Add($fish)
         }
 
         Write-Verbose -Message "Initial state: $(Out-VisualizeSchool -School $school.ToArray())"
         for ($day = 1; $day -le $SimulationDays; $day++) {
             $newFishToAdd = 0
-            foreach($fish in $school) {
-                if($fish.RemainingDays -eq 0) {
-                    $fish.RemainingDays = 6
+            for ($i = 0; $i -lt $school.Count; $i++) {
+                if ($school[$i] -eq 0) {
+                    $school[$i] = 6
                     $newFishToAdd++
                 }
                 else {
-                    $fish.RemainingDays = $fish.RemainingDays - 1
+                    $school[$i] = $school[$i] - 1
                 }
             }
 
             # Add any new fish at the end of the day
             for ($i = 0; $i -lt $newFishToAdd; $i++) {
-                $school.Add($(New-LanternFish -RemainingDays 8))
+                $school.Add( 8)
             }
 
             Write-Verbose -Message "After $("$day".PadLeft(2)) days: $(Out-VisualizeSchool -School $school.ToArray())"
@@ -65,11 +65,14 @@ function Invoke-Simulation {
 }
 
 # Sanity Check for Sample Input 18 Days: 26 Fish
-# Invoke-Simulation -StartingSchool @(3, 4, 3, 1, 2) -SimulationDays 16
+Invoke-Simulation -StartingSchool @(3, 4, 3, 1, 2) -SimulationDays 18 -Verbose
 
 #Sanity Check for Sample Input 80 Days: 5934 Fish
-#Invoke-Simulation -StartingSchool @(3, 4, 3, 1, 2) -SimulationDays 80
+Invoke-Simulation -StartingSchool @(3, 4, 3, 1, 2) -SimulationDays 80
+
+#Sanity Check for Sample Input 256 Days: 26984457539 Fish
+Invoke-Simulation -StartingSchool @(3, 4, 3, 1, 2) -SimulationDays 256
 
 # Perform Actual Input 80 Days: ???
-$startingSchool = @()
-Invoke-Simulation -StartingSchool $startingSchool -SimulationDays 80
+#$startingSchool = @(4,1,1,4,1,1,1,1,1,1,1,1,3,4,1,1,1,3,1,3,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,5,1,2,1,1,5,3,4,2,1,1,4,1,1,5,1,1,5,5,1,1,5,2,1,4,1,2,1,4,5,4,1,1,1,1,3,1,1,1,4,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,5,1,1,2,1,1,1,1,1,1,1,2,4,4,1,1,3,1,3,2,4,3,1,1,1,1,1,2,1,1,1,1,2,5,1,1,1,1,2,1,1,1,1,1,1,1,2,1,1,4,1,5,1,3,1,1,1,1,1,5,1,1,1,3,1,2,1,2,1,3,4,5,1,1,1,1,1,1,5,1,1,1,1,1,1,1,1,3,1,1,3,1,1,4,1,1,1,1,1,2,1,1,1,1,3,2,1,1,1,4,2,1,1,1,4,1,1,2,3,1,4,1,5,1,1,1,2,1,5,3,3,3,1,5,3,1,1,1,1,1,1,1,1,4,5,3,1,1,5,1,1,1,4,1,1,5,1,2,3,4,2,1,5,2,1,2,5,1,1,1,1,4,1,2,1,1,1,2,5,1,1,5,1,1,1,3,2,4,1,3,1,1,2,1,5,1,3,4,4,2,2,1,1,1,1,5,1,5,2)
+#Invoke-Simulation -StartingSchool $startingSchool -SimulationDays 256

--- a/Day6.ps1
+++ b/Day6.ps1
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 Ace Olszowka
 # https://adventofcode.com/2021/day/6
 # How many lanternfish would there be after 80 days?
+# How many lanternfish would there be after 256 days?
 
 function Invoke-Simulation {
     [CmdletBinding()]
@@ -59,7 +60,7 @@ function Invoke-Simulation {
 }
 
 # Sanity Check for Sample Input 18 Days: 26 Fish
-#Invoke-Simulation -StartingSchool @(3, 4, 3, 1, 2) -SimulationDays 18 -Verbose
+#Invoke-Simulation -StartingSchool @(3, 4, 3, 1, 2) -SimulationDays 18
 
 #Sanity Check for Sample Input 80 Days: 5934 Fish
 #Invoke-Simulation -StartingSchool @(3, 4, 3, 1, 2) -SimulationDays 80
@@ -68,5 +69,6 @@ function Invoke-Simulation {
 #Invoke-Simulation -StartingSchool @(3, 4, 3, 1, 2) -SimulationDays 256
 
 # Perform Actual Input 80 Days: ???
+# Perform Actual Input 256 Days: ???
 $startingSchool = @()
 Invoke-Simulation -StartingSchool $startingSchool -SimulationDays 256


### PR DESCRIPTION
https://adventofcode.com/2021/day/6#part2

Part 2 had us use a very large number of days for the simulation which caused the original implementation to break down.

Originally I thought the problem was related to the use of `PSCustomObject`, however even after refactoring this out I was still running to slow.

The next step was to take a look at the implementation, we basically enumerated though every single fish individually which, as the number of fish grew would drastically increase the amount of RAM and enumeration time that this would take. PowerShell in particular is really affected by tight loops.

Therefore the new implementation utilizes a `Dictionary[int,long]` which has 8 "buckets" representing each day that a lantern fish could be in, these buckets are then moved around each day to determine how many fish transition. This allows the memory size to remain fixed and the number of enumerations also to remain fixed; both of which drastically sped up the program.

It was discovered that for most inputs we quickly run out of the `int` range and therefore had to convert to using `long`.

Furthermore it was discovered that the `Write-Verbose` while not called, due to the way the logic was written we still attempted to calculate out what would need to be printed. This was costly and therefore a quick `if` was thrown around this.

A downside of this implementation means that the verbose output for each day no longer matches 1:1 with the sample output (as their sample output is ordered based on the fish, ordering which is lost in this implementation). You can still compare to the sample output but you'll have to order their output numerically to validate it.